### PR TITLE
Fix customizations calls and test more thoroughly

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -207,6 +207,11 @@ class Client {
             ],
         ];
 
+        if ( ! empty( $query ) && ! empty( $query['json'] ) && empty( $params['json'] ) ) {
+            $params['json'] = $query['json'];
+            unset( $query['json'] );
+        }
+
         if ( ! empty( $query ) && empty( $params['query'] ) ) {
             $params['query'] = $query;
         }

--- a/tests/ApiMethodsTraitsTest.php
+++ b/tests/ApiMethodsTraitsTest.php
@@ -221,7 +221,7 @@ trait ApiMethodsTraitTest {
      * Test Client::create_customizations
      */
     public function test_create_customizations() {
-        $customizations = $this->client->create_customizations( $this->video->hashed_id, [ 'playerColor' => 'ffffcc' ] );
+        $customizations = $this->client->create_customizations( $this->video->hashed_id, [ 'json' => [ 'playerColor' => 'ffffcc' ] ] );
 
         $this->assertEquals( 201, $this->client->last_response_code );
         $this->assertInternalType( 'object', $customizations );
@@ -235,7 +235,7 @@ trait ApiMethodsTraitTest {
      * @depends test_create_customizations
      */
     public function test_show_customizations() {
-        $customizations = $this->client->create_customizations( $this->video->hashed_id, [ 'playerColor' => 'ffffcc' ] );
+        $customizations = $this->client->create_customizations( $this->video->hashed_id, [ 'json' => [ 'playerColor' => 'ffffcc' ] ] );
         $customizations = $this->client->show_customizations( $this->video->hashed_id );
 
         $this->assertInternalType( 'object', $customizations );
@@ -249,8 +249,8 @@ trait ApiMethodsTraitTest {
      * @depends test_show_customizations
      */
     public function test_update_customizations() {
-        $customizations = $this->client->create_customizations( $this->video->hashed_id, [ 'playerColor' => 'ffffcc'] );
-        $customizations = $this->client->update_customizations( $this->video->hashed_id, [ 'playerColor' => 'ccffff' ] );
+        $customizations = $this->client->create_customizations( $this->video->hashed_id, [ 'json' => [ 'playerColor' => 'ffffcc' ] ] );
+        $customizations = $this->client->update_customizations( $this->video->hashed_id, [ 'json' => [ 'playerColor' => 'ccffff' ] ] );
 
         $this->assertInternalType( 'object', $customizations );
         $this->assertObjectHasAttribute( 'playerColor', $customizations );

--- a/tests/ApiMethodsTraitsTest.php
+++ b/tests/ApiMethodsTraitsTest.php
@@ -201,7 +201,7 @@ trait ApiMethodsTraitTest {
     public function test_stats_media() {
         $stats = $this->client->stats_media( $this->media->hashed_id );
 
-        $this->assertInternalTupe( 'object', $stats );
+        $this->assertInternalType( 'object', $stats );
         $this->assertObjectHasAttribute( 'stats', $stats );
     }
 

--- a/tests/ApiMethodsTraitsTest.php
+++ b/tests/ApiMethodsTraitsTest.php
@@ -224,6 +224,9 @@ trait ApiMethodsTraitTest {
         $customizations = $this->client->create_customizations( $this->video->hashed_id, [ 'playerColor' => 'ffffcc' ] );
 
         $this->assertEquals( 201, $this->client->last_response_code );
+        $this->assertInternalType( 'object', $customizations );
+        $this->assertObjectHasAttribute( 'playerColor', $customizations );
+        $this->assertEquals( 'ffffcc', $customizations->playerColor );
     }
 
     /**
@@ -232,10 +235,12 @@ trait ApiMethodsTraitTest {
      * @depends test_create_customizations
      */
     public function test_show_customizations() {
+        $customizations = $this->client->create_customizations( $this->video->hashed_id, [ 'playerColor' => 'ffffcc' ] );
         $customizations = $this->client->show_customizations( $this->video->hashed_id );
 
         $this->assertInternalType( 'object', $customizations );
         $this->assertObjectHasAttribute( 'playerColor', $customizations );
+        $this->assertEquals('ffffcc', $customizations->playerColor);
     }
 
     /**
@@ -244,7 +249,7 @@ trait ApiMethodsTraitTest {
      * @depends test_show_customizations
      */
     public function test_update_customizations() {
-        $customizations = $this->client->show_customizations( $this->video->hashed_id );
+        $customizations = $this->client->create_customizations( $this->video->hashed_id, [ 'playerColor' => 'ffffcc'] );
         $customizations = $this->client->update_customizations( $this->video->hashed_id, [ 'playerColor' => 'ccffff' ] );
 
         $this->assertInternalType( 'object', $customizations );

--- a/tests/ApiMethodsTraitsTest.php
+++ b/tests/ApiMethodsTraitsTest.php
@@ -199,7 +199,7 @@ trait ApiMethodsTraitTest {
      * Test Client::stats_media
      */
     public function test_stats_media() {
-        $stats = $this->client->stats_media( $this->media->hashed_id );
+        $stats = $this->client->stats_media( $this->video->hashed_id );
 
         $this->assertInternalType( 'object', $stats );
         $this->assertObjectHasAttribute( 'stats', $stats );


### PR DESCRIPTION
The create_customizations and update_customizations would not work at all. The request has to be made as JSON, so by using a nested params array we can achieve the proper query.

See the documentation: https://wistia.com/support/developers/data-api#customizations_create

Also, I fixed and extended some tests.