### PR TITLE
updating guzzle from 6.x to 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.1"
+        "guzzlehttp/guzzle": "^7"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*"


### PR DESCRIPTION
It'd be awesome if you could bump up guzzle to 7 -- it's causing dep issues